### PR TITLE
Add alternate way of dataset access

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,26 @@ ECCV2020 Challenge
 DroneCrowd (1.03 GB): [BaiduYun](https://pan.baidu.com/share/init?surl=llJZJMi2L5oUQvj31iBlfg)(code: h0j8)| 
 [GoogleDrive](https://drive.google.com/file/d/1HY3V4QObrVjzXUxL_J86oxn2bi7FMUgd/view?usp=sharing)
 
+## How to Use with Hub
+
+A simple way of using this dataset is with [Activeloop](https://activeloop.ai)'s Python package [Hub](https://github.com/activeloopai/Hub), an open-source dataset format for AI that enables you to stream machine learning datasets while training machine learning models!
+
+First, run `pip install hub` (or `pip3 install hub`).
+
+Then, load the dataset:
+
+```py
+import hub
+ds = hub.load("hub://activeloop/visdrone-det-dataset")
+
+# The tensor layout for this dataset can be inspected using:
+ds.summary()
+# The dataset can be also be visualized in the Activeloop 
+# Platform, or using an iframe in a jupyter notebook:
+ds.visualize()
+```
+
+For more information, please check out the [Hub Documentation](https://docs.activeloop.ai)!
 
 ## Citation 
 ```

--- a/README.md
+++ b/README.md
@@ -106,16 +106,27 @@ Then, load the dataset:
 
 ```py
 import hub
-ds = hub.load("hub://activeloop/visdrone-det-dataset")
+# Load training subset
+ds_train = hub.load("hub://activeloop/visdrone-det-train")
 
-# The tensor layout for this dataset can be inspected using:
-ds.summary()
-# The dataset can be also be visualized in the Activeloop 
+# Load testing subset
+ds_test = hub.load("hub://activeloop/visdrone-det-test")
+
+# Load validation subset
+ds_val = hub.load("hub://activeloop/visdrone-det-val")
+
+# Load testing-dev subset
+ds_test_dev = hub.load("hub://activeloop/visdrone-det-test-dev")
+
+# The tensor layout for any dataset can be inspected using:
+ds_train.summary()
+
+# Datasets can be also be visualized in the Activeloop 
 # Platform, or using an iframe in a jupyter notebook:
-ds.visualize()
+ds_train.visualize()
 ```
 
-For more information, please check out the [Hub Documentation](https://docs.activeloop.ai)!
+For more information, please check out the [Hub Documentation](https://docs.activeloop.ai). Specific information about this dataset in Hub can also be found [here](https://docs.activeloop.ai/datasets/visdrone-det-dataset)!
 
 ## Citation 
 ```


### PR DESCRIPTION
Greetings! I'm Dhiganth, a contributor to [Activeloop](https://activeloop.ai)'s Python package, Hub! 

The VisDrone Dataset has been added to Activeloop Hub, an [open-source dataset format for AI](https://github.com/activeloopai/Hub). Users can now load this dataset in seconds by running
```py
import hub
# Load training subset
ds_train = hub.load("hub://activeloop/visdrone-det-train")

# Load testing subset
ds_test = hub.load("hub://activeloop/visdrone-det-test")

# Load validation subset
ds_val = hub.load("hub://activeloop/visdrone-det-val")

# Load testing-dev subset
ds_test_dev = hub.load("hub://activeloop/visdrone-det-test-dev")
```
(with Hub, they can stream the data instead of fully downloading it, so the access is much faster).

Hope this brings value to the community!